### PR TITLE
Handle file's history

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,32 @@ Type: `String`
 
 The path of the file you wish to drop from the remember cache. The path is used under the covers as the unique identifier for the file within one remember cache.
 
-**Important note!** The path you pass to `forget` must be the path of the *processed* file. You may encounter instances where your source file is `some/path/script.coffee` while the processed file is `some/path/script.js`. Because anything could happen before you `remember` a file, it is up to you to know how you need to `forget` it with the correct path.
+**Important note!** The path you pass to `forget` must be the path of the *processed* file. You may encounter instances where your source file is `some/path/script.coffee` while the processed file is `some/path/script.js`. You can use `remember.forgetUsingHistory` (see below) to achieve this.
 
 **Another note:** If the path does not match a file object that exists in the given cache, a warning is logged. Thanks to @jcppman for this.
+
+
+### remember.forgetUsingHistory(name, path)
+
+Drops a file from a remember cache using its history.
+
+#### name (optional)
+
+Type: `String`
+
+The name of the remember cache on which you want to operate. You do not need to pass this if you want to operate on the default remember cache.
+
+**Note:** If the name does not refer to a cache that exists, a warning is logged. Thanks to @jcppman for this.
+
+#### path (required)
+
+Type: `String`
+
+The path of the file you wish to drop from the remember cache. The path is used under the covers as the unique identifier for the file within one remember cache.
+
+The path is also looked for in the file's history.
+
+**Note:** If the path does not match a file object that exists in the given cache, a warning is logged. Thanks to @jcppman for this.
 
 ### remember.forgetAll(name)
 
@@ -104,6 +127,20 @@ Get a raw remember cache. This can be useful for checking state of the cache, li
 Type: `String`
 
 The name of the remember cache you want to retrieve. You do not need to pass this if you want to retrieve the default remember cache.
+
+### remember.historyFor(name)
+
+Get a raw remember history. This can be useful for checking state of the history, like whether or not a file has been seen before.
+
+**Note:** Remembering or forgetting files by interacting directly with this returned object is not recommended.
+
+**Another note:** An history is a map mapping every filenames in each file's history to the last filename seen by `remember`.
+
+#### name (optional)
+
+Type: `String`
+
+The name of the remember history you want to retrieve. You do not need to pass this if you want to retrieve the default remember history.
 
 ## Gotchas
 

--- a/index.js
+++ b/index.js
@@ -20,19 +20,24 @@ function gulpRemember(cacheName) {
     throw new util.PluginError(pluginName, 'Usage: require("gulp-remember")(name); where name is undefined, number or string');
   }
   cacheName = cacheName || defaultName; // maybe need to use a default cache
-  caches[cacheName] = caches[cacheName] || {}; // maybe initialize the named cache
+  caches[cacheName] = caches[cacheName] || {files: {}, history: {}}; // maybe initialize the named cache
   cache = caches[cacheName];
 
   function transform(file, enc, callback) {
-    cache[file.path] = file; // add file to our cache
+    cache.files[file.path] = file; // add file to our cache
+
+    (file.history || []).forEach(function (path) {
+      cache.history[path] = file.path;
+    });
+
     callback();
   }
 
   function flush(callback) {
     // add all files we've ever seen back into the stream
-    for (var path in cache) {
-      if (cache.hasOwnProperty(path)) {
-        this.push(cache[path]); // add this file back into the current stream
+    for (var path in cache.files) {
+      if (cache.files.hasOwnProperty(path)) {
+        this.push(cache.files[path]); // add this file back into the current stream
       }
     }
     callback();
@@ -58,11 +63,41 @@ gulpRemember.forget = function (cacheName, path) {
   }
   if (caches[cacheName] === undefined) {
     util.log(pluginName, '- .forget() warning: cache ' + cacheName + ' not found');
-  } else if (caches[cacheName][path] === undefined) {
+  } else if (caches[cacheName].files[path] === undefined) {
     util.log(pluginName, '- .forget() warning: file ' + path + ' not found in cache ' + cacheName);
   } else {
-    delete caches[cacheName][path];
+    (caches[cacheName].files[path].history || []).forEach(function (path) {
+      delete caches[cacheName].history[path];
+    });
+    delete caches[cacheName].files[path];
   }
+};
+
+/**
+ * Forget about a file using its history.
+ * A warning is logged if either the named cache or file do not exist.
+ *
+ * @param cacheName {string} name of the cache from which to drop the file
+ * @param path {string} path of the file to forget
+ */
+gulpRemember.forgetUsingHistory = function (cacheName, path) {
+  if (arguments.length === 1) {
+    path = cacheName;
+    cacheName = defaultName;
+  }
+  if (typeof cacheName !== 'number' && typeof cacheName !== 'string') {
+    throw new util.PluginError(pluginName, 'Usage: require("gulp-remember").forgetUsingHistory(cacheName, path); where cacheName is undefined, number or string and path is a string');
+  }
+  if (caches[cacheName] === undefined) {
+    return util.log(pluginName, '- .forgetUsingHistory() warning: cache ' + cacheName + ' not found');
+  }
+  if (caches[cacheName].files[path] !== undefined) {
+    return gulpRemember.forget(cacheName, path);
+  }
+  if (caches[cacheName].history[path] === undefined) {
+    return util.log(pluginName, '- .forgetUsingHistory() warning: file ' + path + ' not found in cache ' + cacheName);
+  }
+  return gulpRemember.forget(cacheName, caches[cacheName].history[path]);
 };
 
 /**
@@ -81,9 +116,9 @@ gulpRemember.forgetAll = function (cacheName) {
   if (caches[cacheName] === undefined) {
     util.log(pluginName, '- .forget() warning: cache ' + cacheName + ' not found');
   } else {
-    caches[cacheName] = {};
+    caches[cacheName] = {files: {}, history: {}};
   }
-}
+};
 
 /**
  * Return a raw cache by name.
@@ -98,7 +133,23 @@ gulpRemember.cacheFor = function (cacheName) {
   if (typeof cacheName !== 'number' && typeof cacheName !== 'string') {
     throw new util.PluginError(pluginName, 'Usage: require("gulp-remember").cacheFor(cacheName); where cacheName is undefined, number or string');
   }
-  return caches[cacheName];
-}
+  return (caches[cacheName] || {}).files;
+};
+
+/**
+ * Return a raw history by name.
+ * Useful for checking state. Manually adding or removing files is NOT recommended.
+ *
+ * @param cacheName {string} name of the cache to retrieve
+ */
+gulpRemember.historyFor = function (cacheName) {
+  if (arguments.length === 0) {
+    cacheName = defaultName;
+  }
+  if (typeof cacheName !== 'number' && typeof cacheName !== 'string') {
+    throw new util.PluginError(pluginName, 'Usage: require("gulp-remember").historyFor(cacheName); where cacheName is undefined, number or string');
+  }
+  return (caches[cacheName] || {}).history;
+};
 
 module.exports = gulpRemember;


### PR DESCRIPTION
Mostly add a `forgetUsingHistory` method in order to tackle the need to forget files using the original filename instead of the processed filename.

I'll be glad to tweak this PR anyway you want.

Thanks a lot,