### PR TITLE
the file should be immutable in cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function gulpRemember(cacheName) {
 
   function transform(file, enc, callback) {
     var fileKey = file.path.toLowerCase();
-    cache[fileKey] = file; // add file to our cache
+    cache[fileKey] = file.clone(); // add file to our cache
     callback();
   }
 
@@ -33,7 +33,7 @@ function gulpRemember(cacheName) {
     // add all files we've ever seen back into the stream
     for (var key in cache) {
       if (cache.hasOwnProperty(key)) {
-        this.push(cache[key]); // add this file back into the current stream
+        this.push(cache[key].clone()); // add this file back into the current stream
       }
     }
     callback();

--- a/test/main.js
+++ b/test/main.js
@@ -166,7 +166,7 @@ describe('gulp-remember', function () {
     });
 
 	it('should keep immutable file in cache', function (done) {
-		var stream = remember('noMutation'),
+        var stream = remember('noMutation'),
             file = makeTestFile('fixture/file.js', 'just a file');
 
         stream.on('data', function (file) {

--- a/test/main.js
+++ b/test/main.js
@@ -164,6 +164,22 @@ describe('gulp-remember', function () {
       stream.write(makeTestFile('./fixture/four'));
       stream.end();
     });
+
+	it('should keep immutable file in cache', function (done) {
+		var stream = remember('noMutation'),
+            file = makeTestFile('fixture/file.js', 'just a file');
+
+        stream.on('data', function (file) {
+          file.contents = new Buffer('Different file');
+        });
+        stream.once('end', function () {
+          file.contents.toString().should.equal('just a file');
+          done();
+        });
+
+        stream.write(file);
+        stream.end();
+    });
   });
 
   describe('forget', function () {


### PR DESCRIPTION
The file should be cloned for saving and restoring from cache. It's useful for watch task where babel and other trasformations mutate file content. It's cause that the cache is affected.